### PR TITLE
Feature/modernization

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py35,py36}-{dj111,dj20}
+    {py35,py36}-{dj111,dj20,dj21}
 
 [testenv]
 commands = python manage.py test
@@ -8,6 +8,7 @@ commands = python manage.py test
 deps =
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1a1,<2.2
 
 [pytest]
 DJANGO_SETTINGS_MODULE = venelin.settings.dev

--- a/venelin/blog/templates/blog/base.html
+++ b/venelin/blog/templates/blog/base.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Блог | {{ block.super }}{% endblock %}
 

--- a/venelin/gallery/templates/gallery.html
+++ b/venelin/gallery/templates/gallery.html
@@ -1,5 +1,5 @@
 {% extends "gallery_base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{{ gallery.title }} | {{ block.super }}{% endblock %}
 

--- a/venelin/models.py
+++ b/venelin/models.py
@@ -19,10 +19,14 @@ def get_pages_cache():
 
 
 def invalidate_cache(**kwargs):
-    if kwargs['sender'] in [FlatPage, Entry, Picture, Link]:
-        cache = get_pages_cache()
-        if cache:
-            cache.clear()
+    cache = get_pages_cache()
+    if cache:
+        cache.clear()
 
-for signal in [post_save, m2m_changed, post_delete]:
-    receiver(signal)(invalidate_cache)
+
+# Register Receivers for for cleaning the cache
+_signals = (post_save, m2m_changed, post_delete)
+for _model in (FlatPage, Entry, Picture, Link):
+    receiver(_signals, sender=_model)(invalidate_cache)
+del _signals
+del _model

--- a/venelin/templates/base.html
+++ b/venelin/templates/base.html
@@ -4,7 +4,7 @@
 <!--[if IE 8 ]>    <html lang="{{ LANGUAGE_CODE }}" class="no-js ie8"> <![endif]-->
 <!--[if IE 9 ]>    <html lang="{{ LANGUAGE_CODE }}" class="no-js ie9"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="{{ LANGUAGE_CODE }}" class="no-js"> <!--<![endif]-->
-<head>{% load staticfiles %}
+<head>{% load static %}
 	<meta charset="utf-8">
 	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
- Add support for Django 2.1
- Use `{% load static %}` instead of `{% load staticfiles %}` because from Django 1.10 oif `django.contrib.staticfiles` is installed then `static` template library will do the same.
- Use more optimal approach of connecting for some model signals when we need to clear the cache.